### PR TITLE
A bug in the bytes-identifier

### DIFF
--- a/bug-severity-AFLplusplus/src/cd-bytes-identifier.c
+++ b/bug-severity-AFLplusplus/src/cd-bytes-identifier.c
@@ -1289,10 +1289,16 @@ bruteforce_all:
           else if (cd_res == 3) {
             /* This is a C-D byte at least! */
             /* Very special byte! It can affect the capability-related branch! */
-            if (is_c_and_d_byte || is_c_d_non_byte||is_c_non_byte) {
+            if (is_c_and_d_byte || is_c_d_non_byte) {
               continue;
-            } else if (is_non_crashing_byte && !is_c_d_non_byte) {
-              constraintsRes[i].func_lab += 4;  // C-D-non byte should be equal to 7!
+            } else if (is_c_non_byte && !is_c_d_non_byte ) {
+              constraintsRes[i].func_lab += 2;  // C-D-non byte should be equal to 7!
+              is_c_d_non_byte = 1;
+              break;
+            }
+              else if (is_d_non_byte && !is_c_d_non_byte) {
+              constraintsRes[i].func_lab += 1;  // C-D-non byte should be equal to 7!
+              is_c_d_non_byte = 1;
               break;
             } else if (is_c_byte && !is_c_and_d_byte) {
               constraintsRes[i].func_lab += 2;

--- a/bug-severity-AFLplusplus/src/cd-bytes-identifier.c
+++ b/bug-severity-AFLplusplus/src/cd-bytes-identifier.c
@@ -1289,7 +1289,7 @@ bruteforce_all:
           else if (cd_res == 3) {
             /* This is a C-D byte at least! */
             /* Very special byte! It can affect the capability-related branch! */
-            if (is_c_and_d_byte || is_c_d_non_byte) {
+            if (is_c_and_d_byte || is_c_d_non_byte||is_c_non_byte) {
               continue;
             } else if (is_non_crashing_byte && !is_c_d_non_byte) {
               constraintsRes[i].func_lab += 4;  // C-D-non byte should be equal to 7!


### PR DESCRIPTION
When some bytes are deduced as 'is_non_crashing_byte', if they are deduced as C-D byte, the final func_lab value may be greater than 7